### PR TITLE
Config: Enable use of Environment Variables

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -2,9 +2,32 @@ const fs = require('fs');
 const path = require('path');
 
 const configPath = path.resolve(__dirname, '..', '..', '.config');
+const configVariables = ['appId',
+  'mongoUser',
+  'mongoPass',
+  'mongoAuthSource',
+  'mongoHost',
+  'mongoPort'];
 
 try {
-  module.exports = JSON.parse(fs.readFileSync(configPath));
+
+  // Attempts to pull entire config from environment variables. If any key is
+  // not found, the configuration will instead be drawn from the .config file
+  // which should be placed in the project root.
+  let envUsed = true;
+  configVariables.forEach((envVar) => {
+    if (process.env[envVar] != undefined) {
+      module.exports[envVar] = process.env[envVar]
+    }
+    else {
+      envUsed = false; // If any are empty, the .config file will be used
+    }
+  })
+
+  // Skips if the full config is already in the environment variables
+  if (!envUsed) {
+    module.exports = JSON.parse(fs.readFileSync(configPath));
+  }
 } catch (e) {
   console.log(`No config file found in ${configPath}
 Please run


### PR DESCRIPTION
This patch enables the use of environment variables for passing
configuration to the application. The implementation defers to the
existing configuration method if the complete environment is not
specified, meaning that any existing deployments will be unaffected.

The inclusion of this configuration method allows for simple dockerized
deployments (eg. #11).

Closes #13 

Signed-off-by: Mark Stenglein <mark@stengle.in>