### PR TITLE
Swapped `vw` and `vh` in device css to correct landscape view

### DIFF
--- a/build/css/channel.css
+++ b/build/css/channel.css
@@ -28,8 +28,8 @@ body.right-panel iframe:nth-of-type(2) {
 }
 
 .rot0, .fullscreen {
-  width: 100vh;
-  height: 100vw;
+  width: 100vw;
+  height: 100vh;
 }
 
 .rot90 {


### PR DESCRIPTION
Little fix I did, now rotation works really well 👍 