### PR TITLE
Ensure channel creation does not create empty sections

### DIFF
--- a/app/lib/channels.js
+++ b/app/lib/channels.js
@@ -6,6 +6,36 @@ const devices = require('./devices')
 
 let channels = []
 
+const getMaxSectionCount = layout => {
+  switch (layout || '') {
+    case 'right-panel':
+      return 2
+    default:
+    case 'fullscreen':
+      return 1
+  }
+}
+
+const cleanChannelUrls = channelOpts => {
+  const cleaned = { URLs: [] }
+
+  const maxSectionCount = getMaxSectionCount(channelOpts.layout)
+
+  Object.keys(channelOpts).forEach(key => {
+    if (key.startsWith('URLs')) {
+      const keyIdx = parseInt(key.substring(5, key.length - 1))
+
+      if (!Number.isNaN(keyIdx) && keyIdx < maxSectionCount) {
+        cleaned.URLs[keyIdx] = channelOpts[key]
+      }
+    } else {
+      cleaned[key] = channelOpts[key]
+    }
+  })
+
+  return cleaned
+}
+
 const func = {
   init: () => func.refresh(),
   refresh: () => {
@@ -19,7 +49,7 @@ const func = {
   list: () => channels,
   withId: id => channels.find(c => c._id == id),
   create: (opts, callback) => {
-    var c = new Channel(opts)
+    var c = new Channel(cleanChannelUrls(opts))
     c.save((err, channel) => {
       if (err) console.log(err)
       channels.push(c)
@@ -28,7 +58,7 @@ const func = {
   },
   update: (id, opts, callback) => {
     Channel.update({ _id: id }, opts, err => {
-      Object.assign(func.withId(id), opts)
+      Object.assign(func.withId(id), cleanChannelUrls(opts))
       opts._id = id
       devices.updateChannel(opts, () => callback(id))
     })

--- a/app/lib/cleanObject.js
+++ b/app/lib/cleanObject.js
@@ -1,7 +1,0 @@
-module.exports = obj => {
-  let keys = Object.keys(obj)
-  keys.forEach(k => {
-    if (!obj[k]) delete obj[k]
-  })
-  return obj
-}

--- a/app/routes/channels.js
+++ b/app/routes/channels.js
@@ -8,7 +8,6 @@ const Channel = require('../models/Channel')
 
 const port = require('../lib/config').port
 const squashKeyedArrays = require('../lib/squashKeyedArrays')
-const cleanObject = require('../lib/cleanObject')
 
 router.use((req, res, next) => {
   if (req.body.URLs) req.body.URLs = req.body.URLs.filter(u => u.trim() != '')


### PR DESCRIPTION
Previously when creating a channel the hidden sections were still added to URLs which caused issues when editing the channel. After this change the data is cleaned up before saving.

Signed-off-by: Jyrno Ader <jyrno42@gmail.com>