### PR TITLE
Provide a better error when config could not be loaded

### DIFF
--- a/server/src/services/config.service.ts
+++ b/server/src/services/config.service.ts
@@ -24,7 +24,7 @@ export function loadConfig() {
     const json = readFileSync(configPath, 'utf-8');
     diskConfig = JSON.parse(json);
   } catch (e) {
-    console.error(chalk.yellow('could not load <rootDir>/config.json, exiting...'));
+    console.error(chalk.yellow(`could not load ${configPath}, exiting...`));
     process.exit(1);
   }
 


### PR DESCRIPTION
I found it difficult to understand where this config needed to be. (Probably just me not seeing it) But, it might be helpful to write it all out since you have it available. 